### PR TITLE
修正首頁中Twitter與噗浪項目的圖片與說明文字順序錯置的問題

### DIFF
--- a/app/src/main/java/engineer/kaobei/Fragment/IndexFragment.kt
+++ b/app/src/main/java/engineer/kaobei/Fragment/IndexFragment.kt
@@ -50,10 +50,10 @@ class IndexFragment : Fragment() {
             )
         }
         card3.setOnClickListener {
-            CustomTabUtil.createCustomTab(view.context, "https://plurk.com/kaobei_engineer/")
+            CustomTabUtil.createCustomTab(view.context, "https://twitter.com/kaobei_engineer/")
         }
         card4.setOnClickListener {
-            CustomTabUtil.createCustomTab(view.context, "https://twitter.com/kaobei_engineer/")
+            CustomTabUtil.createCustomTab(view.context, "https://plurk.com/kaobei_engineer/")
         }
         loadNativeAd(view.context, view)
         return view

--- a/app/src/main/res/layout/fragment_index.xml
+++ b/app/src/main/res/layout/fragment_index.xml
@@ -223,7 +223,7 @@
                             android:layout_height="match_parent">
 
                             <ImageView
-                                android:src="@drawable/img_plurk"
+                                android:src="@drawable/img_twitter"
                                 android:layout_width="match_parent"
                                 android:layout_height="match_parent"
                                 android:scaleType="centerCrop" />
@@ -303,7 +303,7 @@
                             android:layout_height="match_parent">
 
                             <ImageView
-                                android:src="@drawable/img_twitter"
+                                android:src="@drawable/img_plurk"
                                 android:layout_width="match_parent"
                                 android:layout_height="match_parent"
                                 android:scaleType="centerCrop" />


### PR DESCRIPTION
~~**此修正未經驗證，合併前應審閱**~~

以說明文字為準統一改為 Twitter→噗浪

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>